### PR TITLE
Fix bug that occurs when context object is deleted

### DIFF
--- a/src/CustomString/widget/CustomString.js
+++ b/src/CustomString/widget/CustomString.js
@@ -67,6 +67,10 @@ define([
 
         _updateRendering : function (callback) {
             logger.debug(this.id + "._updateRendering");
+            if ( this._contextObj == null || typeof this._contextObj == "undefined" ) {
+                this._executeCallback(callback, "_updateRendering emptyObject");
+                return;
+            }
             mx.ui.action(this.sourceMF, {
                 params: {
                     applyto     : "selection",


### PR DESCRIPTION
See below stack trace

Cannot read property 'getGuid' of null TypeError: Cannot read property 'getGuid' of null
    at E.<computed>.O._updateRendering (http://localhost:8080/widgets/CustomString/widget/CustomString.js?637115618090701061:73:53)
    at E.<computed>.O.<anonymous> (http://localhost:8080/widgets/CustomString/widget/CustomString.js?637115618090701061:115:30)
    at E.<computed>.O.<anonymous> (http://localhost:8080/mxclientsystem/mxui/mxui.js?637115618090701061:5:26619)
    at E.<computed>.O._runSubscription (http://localhost:8080/mxclientsystem/mxui/mxui.js?637115618090701061:52:75279)
    at E.<computed>.O.e.callback.e.val.n.callback (http://localhost:8080/mxclientsystem/mxui/mxui.js?637115618090701061:52:74612)